### PR TITLE
feat(sessions): implement admin session closure functionality

### DIFF
--- a/src/components/modal/sessions/modal-admin-sesiones.tsx
+++ b/src/components/modal/sessions/modal-admin-sesiones.tsx
@@ -2,7 +2,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useQueryUserSessions } from "@/hooks/sessions/useQuerySessions";
-import { useMutationCloseSessions } from "@/hooks/sessions/useMutationSessions";
+import { useMutationCloseSessionsAdmin } from "@/hooks/sessions/useMutationSessions";
 import { AplicativoSessionsGroup } from "./aplicativo-sessions-group";
 import { useState } from "react";
 
@@ -15,7 +15,7 @@ interface ModalAdminSesionesProps {
 
 export const ModalAdminSesiones = ({ isOpen, onClose, userId, userName }: ModalAdminSesionesProps) => {
   const { groupedSessions, isLoading, error } = useQueryUserSessions(userId, isOpen);
-  const { mutation, isLoading: isClosing } = useMutationCloseSessions();
+  const { mutation, isLoading: isClosing } = useMutationCloseSessionsAdmin();
   const [loadingSessionIds, setLoadingSessionIds] = useState<Set<number>>(new Set());
   const [loadingGroupIds, setLoadingGroupIds] = useState<Set<number>>(new Set());
 

--- a/src/hooks/sessions/useMutationSessions.ts
+++ b/src/hooks/sessions/useMutationSessions.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { closeSessions } from "@/services/auth/sessions.services";
+import { closeSessions, closeSessionsAdmin } from "@/services/auth/sessions.services";
 import { toast } from "sonner";
 import { AxiosError } from "axios";
 
@@ -8,12 +8,38 @@ export const useMutationCloseSessions = () => {
 
   const mutation = useMutation({
     mutationFn: (sessionIds: number[]) => closeSessions(sessionIds),
-    onSuccess: (data, sessionIds) => {
+    onSuccess: (_data, sessionIds) => {
       queryClient.invalidateQueries({ queryKey: ["sessions"] });
       const count = sessionIds.length;
       toast.success(
         count === 1 
           ? "Sesión cerrada correctamente" 
+          : `${count} sesiones cerradas correctamente`
+      );
+    },
+    onError: (error: AxiosError<{ message?: string; error?: string }>) => {
+      const errorMessage = error.response?.data?.message || error.response?.data?.error || "Error al cerrar la(s) sesión(es)";
+      toast.error(errorMessage);
+    },
+  });
+
+  return {
+    mutation,
+    isLoading: mutation.isPending,
+  };
+};
+
+export const useMutationCloseSessionsAdmin = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (sessionIds: number[]) => closeSessionsAdmin(sessionIds),
+    onSuccess: (_data, sessionIds) => {
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      const count = sessionIds.length;
+      toast.success(
+        count === 1
+          ? "Sesión cerrada correctamente"
           : `${count} sesiones cerradas correctamente`
       );
     },

--- a/src/services/auth/sessions.services.ts
+++ b/src/services/auth/sessions.services.ts
@@ -60,6 +60,32 @@ export const closeSessions = async (sessionIds: number[]): Promise<CloseSessions
 };
 
 /**
+ * Cierra sesiones de forma administrativa.
+ * Requiere permisos de staff en backend.
+ */
+export const closeSessionsAdmin = async (sessionIds: number[]): Promise<CloseSessionsResponse> => {
+  if (!sessionIds || sessionIds.length === 0) {
+    throw new Error("No session IDs provided");
+  }
+
+  if (!sessionIds.every(id => Number.isInteger(id) && id > 0)) {
+    throw new Error("Invalid session IDs: all IDs must be positive integers");
+  }
+
+  const body: CloseSessionsRequest = {
+    sessions: sessionIds,
+  };
+
+  const res = await apiServices.patch<CloseSessionsResponse>("/auth/sessions/", body);
+
+  if (!res.data || !res.data.message) {
+    throw new Error("Invalid response format from server");
+  }
+
+  return res.data;
+};
+
+/**
  * Obtiene las sesiones activas del usuario autenticado
  * @returns Lista de sesiones activas del usuario
  */


### PR DESCRIPTION
- Added a new hook `useMutationCloseSessionsAdmin` to handle administrative session closures, utilizing the `closeSessionsAdmin` service.
- Updated the `ModalAdminSesiones` component to use the new hook for closing sessions.
- Enhanced the `closeSessionsAdmin` service to include validation and improved error handling for session closure requests.