### PR TITLE
feat(mi-acceso): mejorar alta de movimientos

### DIFF
--- a/src/app/admin/mi-acceso/__tests__/movements-utils.test.ts
+++ b/src/app/admin/mi-acceso/__tests__/movements-utils.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 
 import type { Movement } from "../movements-data";
-import { buildValidationMap, generateCredentialsFromName, serializeMovementsPayload } from "../movements-utils";
+import { buildValidationMap, generateCredentialsFromName, generateMovementPassword, parseMovementApiErrors, serializeMovementsPayload } from "../movements-utils";
 
 const agencies = [
   { id: 1, name: "Central" },
@@ -14,11 +14,22 @@ const roles = [
 ];
 
 describe("movements-utils", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("genera username y correo a partir del nombre completo", () => {
     expect(generateCredentialsFromName("Juan Pablo Perez")).toEqual({
       email: "jpperez@acredicom.com.gt",
       username: "mcjpperez",
     });
+  });
+
+  it("genera la contraseña automática con mes y año actuales", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-29T12:00:00.000Z"));
+
+    expect(generateMovementPassword()).toBe("Mayo2026.");
   });
 
   it("valida los nuevos campos obligatorios para alta", () => {
@@ -33,12 +44,10 @@ describe("movements-utils", () => {
     expect(buildValidationMap([movement])).toEqual({
       "m-1": {
         newAgency: "La agencia es requerida.",
-        newConfirmPassword: "La confirmación de contraseña es requerida.",
         newDpi: "El DPI es requerido.",
         newEmail: "El correo es requerido.",
         newId: "El ID de empleado es requerido.",
         newName: "El nombre completo es requerido.",
-        newPassword: "La contraseña es requerida.",
         newPosition: "El puesto es requerido.",
         newUsername: "El username es requerido.",
       },
@@ -187,5 +196,85 @@ describe("movements-utils", () => {
     expect(() => serializeMovementsPayload([movement], { agencies, roles })).toThrow(
       'No se pudo resolver la agencia "Inexistente".',
     );
+  });
+
+  it("parsea errores anidados del backend y desbloquea credenciales", () => {
+    const movement: Movement = {
+      id: "alta-1",
+      actionType: "alta",
+      effectiveDate: "2026-05-26",
+      collaborator: null,
+      newName: "Juan Pablo Perez",
+      newDpi: "1234567890123",
+      newId: "4567",
+      newUsername: "mcjpperez",
+      newEmail: "jpperez@acredicom.com.gt",
+      newPassword: "PasswordSegura123!",
+      newConfirmPassword: "PasswordSegura123!",
+      newAgency: "Central",
+      newPosition: "Analista",
+      observations: "Alta nueva",
+    };
+
+    expect(
+      parseMovementApiErrors(
+        [
+          {
+            colaborador: {
+              username: "Este nombre de usuario ya está registrado.",
+            },
+          },
+        ],
+        [movement],
+      ),
+    ).toEqual({
+      validationMap: {
+        "alta-1": {
+          newUsername: "Este nombre de usuario ya está registrado.",
+          submit: "Este nombre de usuario ya está registrado.",
+        },
+      },
+      shouldUnlockCredentials: ["alta-1"],
+      toastMessage: "Este nombre de usuario ya está registrado.",
+    });
+  });
+
+  it("parsea errores del backend cuando llegan como objeto simple", () => {
+    const movement: Movement = {
+      id: "alta-1",
+      actionType: "alta",
+      effectiveDate: "2026-05-26",
+      collaborator: null,
+      newName: "Juan Pablo Perez",
+      newDpi: "1234567890123",
+      newId: "4567",
+      newUsername: "mcjpperez",
+      newEmail: "jpperez@acredicom.com.gt",
+      newPassword: "PasswordSegura123!",
+      newConfirmPassword: "PasswordSegura123!",
+      newAgency: "Central",
+      newPosition: "Analista",
+      observations: "Alta nueva",
+    };
+
+    expect(
+      parseMovementApiErrors(
+        {
+          colaborador: {
+            username: "Este nombre de usuario ya está registrado.",
+          },
+        },
+        [movement],
+      ),
+    ).toEqual({
+      validationMap: {
+        "alta-1": {
+          newUsername: "Este nombre de usuario ya está registrado.",
+          submit: "Este nombre de usuario ya está registrado.",
+        },
+      },
+      shouldUnlockCredentials: ["alta-1"],
+      toastMessage: "Este nombre de usuario ya está registrado.",
+    });
   });
 });

--- a/src/app/admin/mi-acceso/__tests__/page.test.tsx
+++ b/src/app/admin/mi-acceso/__tests__/page.test.tsx
@@ -74,6 +74,14 @@ vi.mock("@/hooks/auth/usePermissionAccess", () => ({
   }),
 }));
 
+vi.mock("../movements-utils", async () => {
+  const actual = await vi.importActual("../movements-utils");
+  return {
+    ...actual,
+    generateMovementPassword: vi.fn(() => "Mayo2026."),
+  };
+});
+
 function renderPage() {
   return render(
     <MemoryRouter initialEntries={["/mi-acceso"]}>
@@ -121,8 +129,6 @@ describe("MiAccesoPage", () => {
     expect(screen.getByText("El ID de empleado es requerido.")).toBeInTheDocument();
     expect(screen.getByText("El username es requerido.")).toBeInTheDocument();
     expect(screen.getByText("El correo es requerido.")).toBeInTheDocument();
-    expect(screen.getByText("La contraseña es requerida.")).toBeInTheDocument();
-    expect(screen.getByText("La confirmación de contraseña es requerida.")).toBeInTheDocument();
     expect(mutationState.mutateAsync).not.toHaveBeenCalled();
   });
 
@@ -140,8 +146,9 @@ describe("MiAccesoPage", () => {
     await user.type(screen.getByLabelText("ID de empleado *"), "4567");
     expect(screen.getByLabelText("Username *")).toHaveValue("mcjpperez");
     expect(screen.getByLabelText("Correo electrónico *")).toHaveValue("jpperez@acredicom.com.gt");
-    await user.type(screen.getByLabelText("Contraseña *"), "PasswordSegura123!");
-    await user.type(screen.getByLabelText("Confirmar contraseña *"), "PasswordSegura123!");
+    expect(screen.getByLabelText("Contraseña *")).toHaveValue("Mayo2026.");
+    expect(screen.getByLabelText("Contraseña *")).toBeDisabled();
+    expect(screen.queryByLabelText("Confirmar contraseña *")).not.toBeInTheDocument();
 
     const comboboxes = screen.getAllByRole("combobox");
     await user.click(comboboxes[0]);
@@ -160,7 +167,7 @@ describe("MiAccesoPage", () => {
             nombre: "Juan Pablo Perez",
             username: "mcjpperez",
             email: "jpperez@acredicom.com.gt",
-            password: "PasswordSegura123!",
+            password: "Mayo2026.",
             dpi: "1234567890123",
             cif: "4567",
             agency_id: 1,
@@ -202,5 +209,46 @@ describe("MiAccesoPage", () => {
     expect(screen.getByRole("combobox", { name: /Puesto/i })).toBeDisabled();
     expect(screen.getByText("Sin permiso para listar agencias")).toBeInTheDocument();
     expect(screen.getByText("Sin permiso para listar puestos")).toBeInTheDocument();
+  });
+
+  it("habilita username y correo cuando backend reporta username duplicado y muestra el error", async () => {
+    const user = userEvent.setup();
+    mutationState.mutateAsync.mockRejectedValueOnce({
+      response: {
+        data: {
+          colaborador: {
+            username: "Este nombre de usuario ya está registrado.",
+          },
+        },
+      },
+    });
+
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: /Añadir movimiento/i }));
+    await user.click(screen.getByRole("menuitem", { name: "Alta" }));
+
+    await user.type(screen.getByLabelText("Nombre completo *"), "Juan Pablo Perez");
+    await user.type(screen.getByLabelText("DPI *"), "1234567890123");
+    await user.type(screen.getByLabelText("ID de empleado *"), "4567");
+
+    const comboboxes = screen.getAllByRole("combobox");
+    await user.click(comboboxes[0]);
+    await user.click(screen.getByText("Central"));
+    await user.click(comboboxes[1]);
+    await user.click(screen.getByText("Analista"));
+
+    expect(screen.getByLabelText("Username *")).toBeDisabled();
+    expect(screen.getByLabelText("Correo electrónico *")).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /Confirmar 1 movimiento/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Este nombre de usuario ya está registrado.");
+    });
+
+    expect(screen.getByLabelText("Username *")).not.toBeDisabled();
+    expect(screen.getByLabelText("Correo electrónico *")).not.toBeDisabled();
+    expect(toast.error).toHaveBeenCalledWith("Este nombre de usuario ya está registrado.");
   });
 });

--- a/src/app/admin/mi-acceso/movement-card.tsx
+++ b/src/app/admin/mi-acceso/movement-card.tsx
@@ -74,7 +74,10 @@ export function MovementCard({
   const usernameValue = movement.newUsername ?? "";
   const emailValue = movement.newEmail ?? "";
   const passwordValue = movement.newPassword ?? "";
-  const confirmPasswordValue = movement.newConfirmPassword ?? "";
+  const allowCredentialEdit = Boolean(movement.allowCredentialEdit);
+  const hasCredentialConflict = allowCredentialEdit && Boolean(
+    movementErrors.newUsername || movementErrors.newEmail || movementErrors.submit,
+  );
   const dpiError =
     movementErrors.newDpi ||
     (isAlta && dpiValue.length > 0 && dpiValue.length !== 13
@@ -255,8 +258,13 @@ export function MovementCard({
                     placeholder="Ej. mcjperez"
                     value={usernameValue}
                     onChange={(event) => update({ newUsername: event.target.value.trim() })}
-                    disabled
+                    disabled={!allowCredentialEdit}
                   />
+                  <FieldDescription>
+                    {allowCredentialEdit
+                      ? "Puedes ajustar el username si el sistema detectó un conflicto."
+                      : "Se genera automáticamente a partir del nombre."}
+                  </FieldDescription>
                   <FieldError>{movementErrors.newUsername}</FieldError>
                 </FieldContent>
               </Field>
@@ -267,16 +275,25 @@ export function MovementCard({
                 <FieldLabel htmlFor={`email-${movement.id}`}>Correo electrónico *</FieldLabel>
                 <FieldContent>
                   <Input
-                    aria-invalid={!!movementErrors.newEmail}
-                    className={movementErrors.newEmail ? "border-destructive focus-visible:ring-destructive/40" : undefined}
+                    aria-invalid={!!movementErrors.newEmail || hasCredentialConflict}
+                    className={
+                      movementErrors.newEmail || hasCredentialConflict
+                        ? "border-destructive focus-visible:ring-destructive/40"
+                        : undefined
+                    }
                     id={`email-${movement.id}`}
                     inputMode="email"
                     placeholder="usuario@acredicom.com.gt"
                     type="email"
                     value={emailValue}
                     onChange={(event) => update({ newEmail: event.target.value.trim() })}
-                    disabled
+                    disabled={!allowCredentialEdit}
                   />
+                  <FieldDescription>
+                    {allowCredentialEdit
+                      ? "Puedes ajustar el correo si el sistema detectó un conflicto."
+                      : "Se genera automáticamente a partir del nombre."}
+                  </FieldDescription>
                   <FieldError>{movementErrors.newEmail}</FieldError>
                 </FieldContent>
               </Field>
@@ -288,28 +305,13 @@ export function MovementCard({
                     aria-invalid={!!movementErrors.newPassword}
                     className={movementErrors.newPassword ? "border-destructive focus-visible:ring-destructive/40" : undefined}
                     id={`password-${movement.id}`}
-                    placeholder="Contraseña de acceso"
-                    type="password"
+                    placeholder="Contraseña generada automáticamente"
+                    type="text"
                     value={passwordValue}
-                    onChange={(event) => update({ newPassword: event.target.value })}
+                    disabled
                   />
-                  <FieldError>{movementErrors.newPassword}</FieldError>
-                </FieldContent>
-              </Field>
-
-              <Field>
-                <FieldLabel htmlFor={`confirm-password-${movement.id}`}>Confirmar contraseña *</FieldLabel>
-                <FieldContent>
-                  <Input
-                    aria-invalid={!!movementErrors.newConfirmPassword}
-                    className={movementErrors.newConfirmPassword ? "border-destructive focus-visible:ring-destructive/40" : undefined}
-                    id={`confirm-password-${movement.id}`}
-                    placeholder="Repite la contraseña"
-                    type="password"
-                    value={confirmPasswordValue}
-                    onChange={(event) => update({ newConfirmPassword: event.target.value })}
-                  />
-                  <FieldError>{movementErrors.newConfirmPassword}</FieldError>
+                  <FieldDescription>Se genera automáticamente con el mes y año actuales.</FieldDescription>
+                  <FieldError>{movementErrors.newPassword || movementErrors.newConfirmPassword}</FieldError>
                 </FieldContent>
               </Field>
 
@@ -348,6 +350,14 @@ export function MovementCard({
                   <FieldError>{movementErrors.newPosition}</FieldError>
                 </FieldContent>
               </Field>
+            </div>
+
+            <div className="lg:col-span-2">
+              {movementErrors.submit ? (
+                <div className="rounded-xl border border-destructive/25 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+                  {movementErrors.submit}
+                </div>
+              ) : null}
             </div>
 
             <Field className="lg:col-span-2">

--- a/src/app/admin/mi-acceso/movements-data.ts
+++ b/src/app/admin/mi-acceso/movements-data.ts
@@ -21,6 +21,7 @@ export interface Movement {
   actionType: ActionType;
   effectiveDate: string;
   collaborator: CollaboratorInfo | null;
+  allowCredentialEdit?: boolean;
   newName?: string;
   newDpi?: string;
   newId?: string;
@@ -44,7 +45,8 @@ export type MovementFieldName =
   | "newName"
   | "newPassword"
   | "newPosition"
-  | "newUsername";
+  | "newUsername"
+  | "submit";
 
 export type MovementValidationErrors = Partial<Record<MovementFieldName, string>>;
 

--- a/src/app/admin/mi-acceso/movements-utils.ts
+++ b/src/app/admin/mi-acceso/movements-utils.ts
@@ -6,6 +6,20 @@ import { splitName } from "@/lib/splitName";
 import { ACTION_LABELS, type ActionType, type Movement, type MovementValidationErrors } from "./movements-data";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const SPANISH_MONTHS = [
+  "Enero",
+  "Febrero",
+  "Marzo",
+  "Abril",
+  "Mayo",
+  "Junio",
+  "Julio",
+  "Agosto",
+  "Septiembre",
+  "Octubre",
+  "Noviembre",
+  "Diciembre",
+] as const;
 
 function normalizeString(value: string) {
   return value
@@ -30,6 +44,13 @@ export function generateCredentialsFromName(fullName: string) {
     email: `${firstInitial}${secondInitial}${normalizedLastName}@acredicom.com.gt`,
     username: `mc${firstInitial}${secondInitial}${normalizedLastName}`,
   };
+}
+
+export function generateMovementPassword(referenceDate = new Date()) {
+  const month = SPANISH_MONTHS[referenceDate.getMonth()];
+  const year = referenceDate.getFullYear();
+
+  return `${month}${year}.`;
 }
 
 export function buildMovementSummary(movements: Movement[]) {
@@ -82,16 +103,6 @@ export function validateMovement(movement: Movement): MovementValidationErrors {
       errors.newEmail = "El correo es requerido.";
     } else if (!EMAIL_REGEX.test(movement.newEmail.trim())) {
       errors.newEmail = "El correo debe ser válido.";
-    }
-
-    if (!movement.newPassword?.trim()) {
-      errors.newPassword = "La contraseña es requerida.";
-    }
-
-    if (!movement.newConfirmPassword?.trim()) {
-      errors.newConfirmPassword = "La confirmación de contraseña es requerida.";
-    } else if (movement.newPassword !== movement.newConfirmPassword) {
-      errors.newConfirmPassword = "Las contraseñas no coinciden.";
     }
 
     if (!movement.newAgency?.trim()) {
@@ -223,6 +234,7 @@ export function serializeMovement(
   { agencies, roles }: SerializeMovementsOptions,
 ): CreateMovementPayload {
   if (movement.actionType === "alta") {
+    const generatedPassword = movement.newPassword?.trim() || generateMovementPassword();
     const agencyId = ensureId(
       resolveAgencyId(movement.newAgency, agencies),
       `No se pudo resolver la agencia "${movement.newAgency ?? ""}".`,
@@ -240,7 +252,7 @@ export function serializeMovement(
         nombre: movement.newName?.trim() ?? "",
         username: movement.newUsername?.trim() ?? "",
         email: movement.newEmail?.trim() ?? "",
-        password: movement.newPassword?.trim() ?? "",
+        password: generatedPassword,
         dpi: movement.newDpi?.trim() ?? "",
         cif: movement.newId?.trim() ?? "",
         agency_id: agencyId,
@@ -278,4 +290,141 @@ export function serializeMovementsPayload(
   options: SerializeMovementsOptions,
 ) {
   return movements.map((movement) => serializeMovement(movement, options));
+}
+
+function getFirstNestedString(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = getFirstNestedString(item);
+      if (nested) {
+        return nested;
+      }
+    }
+    return undefined;
+  }
+
+  if (value && typeof value === "object") {
+    for (const nestedValue of Object.values(value)) {
+      const nested = getFirstNestedString(nestedValue);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+interface ParsedMovementApiError {
+  validationMap: Record<string, MovementValidationErrors>;
+  shouldUnlockCredentials: string[];
+  toastMessage?: string;
+}
+
+function buildCredentialErrorsFromApiItem(
+  item: Record<string, unknown>,
+  movement: Movement | undefined,
+) {
+  if (!movement) {
+    return undefined;
+  }
+
+  const collaboratorErrors =
+    "colaborador" in item && item.colaborador && typeof item.colaborador === "object"
+      ? (item.colaborador as Record<string, unknown>)
+      : undefined;
+
+  const movementErrors: MovementValidationErrors = {};
+  let shouldUnlock = false;
+
+  const usernameError =
+    collaboratorErrors && typeof collaboratorErrors.username === "string"
+      ? collaboratorErrors.username
+      : undefined;
+
+  const emailError =
+    collaboratorErrors && typeof collaboratorErrors.email === "string"
+      ? collaboratorErrors.email
+      : undefined;
+
+  if (usernameError) {
+    movementErrors.newUsername = usernameError;
+    shouldUnlock = true;
+  }
+
+  if (emailError) {
+    movementErrors.newEmail = emailError;
+    shouldUnlock = true;
+  }
+
+  const rootError = getFirstNestedString(item);
+  if (rootError) {
+    movementErrors.submit = rootError;
+  }
+
+  if (Object.keys(movementErrors).length === 0) {
+    return undefined;
+  }
+
+  return {
+    movementId: movement.id,
+    movementErrors,
+    shouldUnlock,
+  };
+}
+
+export function parseMovementApiErrors(
+  errorData: unknown,
+  movements: Movement[],
+): ParsedMovementApiError {
+  const validationMap: Record<string, MovementValidationErrors> = {};
+  const shouldUnlockCredentials = new Set<string>();
+
+  if (Array.isArray(errorData)) {
+    errorData.forEach((item, index) => {
+      if (!item || typeof item !== "object") {
+        return;
+      }
+
+      const parsed = buildCredentialErrorsFromApiItem(item as Record<string, unknown>, movements[index]);
+      if (!parsed) {
+        return;
+      }
+
+      validationMap[parsed.movementId] = parsed.movementErrors;
+      if (parsed.shouldUnlock) {
+        shouldUnlockCredentials.add(parsed.movementId);
+      }
+    });
+  } else if (errorData && typeof errorData === "object") {
+    const candidateMovement =
+      movements.find((movement) => movement.actionType === "alta") ??
+      movements[0];
+
+    const parsed = buildCredentialErrorsFromApiItem(
+      errorData as Record<string, unknown>,
+      candidateMovement,
+    );
+
+    if (parsed) {
+      validationMap[parsed.movementId] = parsed.movementErrors;
+      if (parsed.shouldUnlock) {
+        shouldUnlockCredentials.add(parsed.movementId);
+      }
+    }
+  }
+
+  const toastMessage =
+    getFirstNestedString(errorData) ||
+    "No se pudieron registrar los movimientos.";
+
+  return {
+    validationMap,
+    shouldUnlockCredentials: [...shouldUnlockCredentials],
+    toastMessage,
+  };
 }

--- a/src/app/admin/mi-acceso/page.tsx
+++ b/src/app/admin/mi-acceso/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { AxiosError } from "axios";
 import { CheckCircle2, ChevronDown, ClipboardList, Loader2, Plus } from "lucide-react";
 import { toast } from "sonner";
 
@@ -23,7 +24,7 @@ import {
 
 import { ACTION_LABELS, getTodayEffectiveDate, type ActionType, type Movement, type MovementValidationErrors } from "./movements-data";
 import { MovementCard } from "./movement-card";
-import { buildMovementSummary, buildValidationMap, serializeMovementsPayload } from "./movements-utils";
+import { buildMovementSummary, buildValidationMap, generateMovementPassword, parseMovementApiErrors, serializeMovementsPayload } from "./movements-utils";
 
 export default function MiAccesoPage() {
   const [movements, setMovements] = useState<Movement[]>([]);
@@ -106,6 +107,12 @@ export default function MiAccesoPage() {
         actionType,
         effectiveDate: getTodayEffectiveDate(),
         collaborator: null,
+        ...(actionType === "alta"
+          ? {
+              newPassword: generateMovementPassword(),
+              newConfirmPassword: generateMovementPassword(),
+            }
+          : {}),
         observations: "",
       },
     ]);
@@ -145,8 +152,39 @@ export default function MiAccesoPage() {
       toast.success("Movimientos registrados correctamente", {
         description: buildMovementSummary(movements),
       });
-    } catch {
-      // El hook de mutation ya muestra el mensaje de error.
+    } catch (error) {
+      const apiError = error as AxiosError<unknown>;
+      const { validationMap: apiValidationMap, shouldUnlockCredentials, toastMessage } = parseMovementApiErrors(
+        apiError.response?.data,
+        movements,
+      );
+
+      if (Object.keys(apiValidationMap).length > 0) {
+        setValidationErrors((previous) => {
+          const nextMap = { ...previous };
+
+          Object.entries(apiValidationMap).forEach(([movementId, errors]) => {
+            nextMap[movementId] = {
+              ...(nextMap[movementId] ?? {}),
+              ...errors,
+            };
+          });
+
+          return nextMap;
+        });
+      }
+
+      if (shouldUnlockCredentials.length > 0) {
+        setMovements((previous) =>
+          previous.map((movement) =>
+            shouldUnlockCredentials.includes(movement.id)
+              ? { ...movement, allowCredentialEdit: true }
+              : movement,
+          ),
+        );
+      }
+
+      toast.error(toastMessage);
     }
   };
 

--- a/src/hooks/movements/useMutationMovements.ts
+++ b/src/hooks/movements/useMutationMovements.ts
@@ -1,23 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
-import { AxiosError } from "axios";
-import { toast } from "sonner";
 
 import { createMovements } from "@/services/movements/movements.services";
-
-type MovementsApiError = AxiosError<{ message?: string; error?: string; detail?: string }>;
 
 export const useMutationCreateMovements = () => {
   const mutation = useMutation({
     mutationFn: createMovements,
-    onError: (error: MovementsApiError) => {
-      const errorMessage =
-        error.response?.data?.message ||
-        error.response?.data?.error ||
-        error.response?.data?.detail ||
-        "No se pudieron registrar los movimientos.";
-
-      toast.error(errorMessage);
-    },
   });
 
   return {


### PR DESCRIPTION
## Resumen
Este PR refuerza el flujo de `Mi Acceso` para registrar movimientos de personal y mejora la recuperación cuando el backend rechaza credenciales generadas automáticamente.
## Cambios principales
- Se agregó contraseña automática para altas, usando el mes y año actuales.
- Se mejoró el parseo de errores del backend para mostrar validaciones anidadas de forma clara.
- Cuando el backend detecta conflicto en `username` o `email`, se habilita la edición manual de esos campos.
- Se actualizaron los tests del flujo de alta para cubrir credenciales, validación y manejo de errores.
- Se ajustó la UI de captura para reflejar estados de error y edición desbloqueada.
## Impacto
- El alta de movimientos queda más robusta ante rechazos del backend.
- La experiencia de captura mejora porque el usuario ve el error exacto y puede corregirlo sin reiniciar el formulario.
